### PR TITLE
invisibly return component plots

### DIFF
--- a/R/R/prophet.R
+++ b/R/R/prophet.R
@@ -917,6 +917,8 @@ plot.prophet <- function(x, fcst, uncertainty = TRUE, ...) {
 #' @param uncertainty Boolean indicating if the uncertainty interval should be
 #'  plotted for the trend, from fcst columns trend_lower and trend_upper.
 #'
+#' @return Invisibly return a list containing the plotted ggplot objects
+#'
 #' @export
 #' @importFrom dplyr "%>%"
 prophet_plot_components <- function(m, fcst, uncertainty = TRUE) {
@@ -1020,6 +1022,7 @@ prophet_plot_components <- function(m, fcst, uncertainty = TRUE) {
     print(panels[[i]], vp = grid::viewport(layout.pos.row = i,
                                            layout.pos.col = 1))
   }
+  return(invisible(panels))
 }
 
 # fb-block 3


### PR DESCRIPTION
This will make it easier for users to change the theme or other aspects of the plots, and shouldn't affect any existing behavior because the returned object is invisible.