### PR TITLE
fix issue 66

### DIFF
--- a/python/fbprophet/forecaster.py
+++ b/python/fbprophet/forecaster.py
@@ -202,7 +202,7 @@ class Prophet(object):
         # convert to days since epoch
         t = np.array(
             (dates - pd.datetime(1970, 1, 1))
-            .apply(lambda x: x.days)
+            .dt.days
             .astype(np.float)
         )
         return np.column_stack([

--- a/python/setup.py
+++ b/python/setup.py
@@ -83,7 +83,7 @@ setup(
     install_requires=[
         'matplotlib',
         'numpy',
-        'pandas',
+        'pandas>=0.16',
         'pystan>=2.8',
     ],
     zip_safe=False,


### PR DESCRIPTION
Fix issue #66, thanks to @datafool
1. `pandas.Series.apply` throws error in `Prophet.fit` function with `pandas 0.17.1`.
`pandas.Series.dt.days` is equivalent to `pandas.Series.apply`, but is more efficient.
2. `pandas.Series.dt.days` is available from `0.16`.