### PR TITLE
#78 Automatic detection of data aggregation for creating weekly seasonality 

### DIFF
--- a/python/fbprophet/forecaster.py
+++ b/python/fbprophet/forecaster.py
@@ -127,14 +127,20 @@ class Prophet(object):
 
     def setup_dataframe(self, df, initialize_scales=False):
         """Create auxillary columns 't', 't_ix', 'y_scaled', and 'cap_scaled'.
+        If minimum difference between two dates of data is more than 7, then 
+        we don't create weekly seasonality
 
         These columns are used during both fitting and prediction.
         """
         if 'y' in df:
             df['y'] = pd.to_numeric(df['y'])
         df['ds'] = pd.to_datetime(df['ds'])
-
+        
         df = df.sort_values('ds')
+
+        if (df.ds - df.ds.shift(1)).dt.days.min() >=7:
+            self.weekly_seasonality = False
+
         df.reset_index(inplace=True, drop=True)
 
         if initialize_scales:

--- a/python/fbprophet/forecaster.py
+++ b/python/fbprophet/forecaster.py
@@ -40,7 +40,7 @@ class Prophet(object):
             changepoints=None,
             n_changepoints=25,
             yearly_seasonality=True,
-            weekly_seasonality=True,
+            weekly_seasonality='auto',
             holidays=None,
             seasonality_prior_scale=10.0,
             holidays_prior_scale=10.0,
@@ -138,7 +138,7 @@ class Prophet(object):
         
         df = df.sort_values('ds')
 
-        if (df.ds - df.ds.shift(1)).dt.days.min() >=7:
+        if self.weekly_seasonality=='auto' and  df.ds - df.ds.shift(1)).dt.days.min() >=7:
             self.weekly_seasonality = False
 
         df.reset_index(inplace=True, drop=True)


### PR DESCRIPTION
#78 
- Changed setup_dataframe, so that if minimum difference between two  dates of data is more than 7 days then weekly seasonality is not created
- This will rectify the error in plot_component, when weekly aggregated data is used. For more detail refer to issue #78 
