### PR TITLE
Fix pickling protocol to use highest available.

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -31,7 +31,7 @@ class BuildPyCommand(build_py):
                 model_code = f.read()
             sm = StanModel(model_code=model_code)
             with open(os.path.join(target_dir, '{}_growth.pkl'.format(model_type)), 'wb') as f:
-                pickle.dump(sm, f)
+                pickle.dump(sm, f, protocol=pickle.HIGHEST_PROTOCOL)
 
 class TestCommand(test_command):
     """We must run tests on the build directory, not source."""


### PR DESCRIPTION
This fixes unpickling errors in Python 2.7 as it defaults to the text
protocol which causes binary corruption.

--

This caused the following errors in OSX and Linux respectively.

```
===== testing package: fbprophet-0.1.post1-np111py27_0 =====
running run_test.py
WARNING:pystan:dlopen(/var/folders/vy/rcv48w3j4w79llzf_x6qnvw40000gn/T/tmpeM5mgo/stanfit4anon_model_c153dc7d0d8ff6155539d8341c0db2d1_4552246772491135307.so, 2): no suitable image found.  Did find:
	/var/folders/vy/rcv48w3j4w79llzf_x6qnvw40000gn/T/tmpeM5mgo/stanfit4anon_model_c153dc7d0d8ff6155539d8341c0db2d1_4552246772491135307.so: malformed mach-o image: load command #12 length (0) too small in /var/folders/vy/rcv48w3j4w79llzf_x6qnvw40000gn/T/tmpeM5mgo/stanfit4anon_model_c153dc7d0d8ff6155539d8341c0db2d1_4552246772491135307.so
WARNING:pystan:Something went wrong while unpickling the StanModel. Consider recompiling.
```

```
===== testing package: fbprophet-0.1.post2-np111py27_0 =====
running run_test.py
============================= test session starts ==============================
platform linux2 -- Python 2.7.12, pytest-3.0.6, py-1.4.31, pluggy-0.4.0 -- /staged-recipes/build_artefacts/fbprophet_1488999007414/_t_env/bin/python
cachedir: ../.cache
rootdir: /staged-recipes/build_artefacts/fbprophet_1488999007414, inifile: 
collecting ... collected 16 items

../_t_env/lib/python2.7/site-packages/fbprophet/tests/test_prophet.py::TestProphet::test_fit_changepoint_not_in_history 
/staged-recipes/build_artefacts/fbprophet_1488999007414/test_tmp/conda_test_runner.sh: line 2:   277 Segmentation fault      (core dumped)
```