### PR TITLE
Modify setup.py so pip install completes succesfully

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -104,12 +104,9 @@ setup(
     license='BSD',
     packages=['fbprophet', 'fbprophet.tests'],
     setup_requires=[
-        'Cython>=0.22',
-        'pystan>=2.14',
     ],
     install_requires=[
         'matplotlib',
-        'numpy',
         'pandas>=0.18.1',
         'pystan>=2.14',
     ],


### PR DESCRIPTION
Including pystan & Cython in the setup_requires caused pip install to fail with a complaint about missing
Cython and numpy dependencies.  Removing the explicit Cython/numpy dependencies allows pip install to complete successfully (pystan pulls in the Cython/numpy dependencies itself).

Tested on Ubuntu (Python 3.5 & 2.7) but should be ok on other platforms as well.