### PR TITLE
Refine R code a little

### DIFF
--- a/R/DESCRIPTION
+++ b/R/DESCRIPTION
@@ -22,8 +22,7 @@ Imports:
     rstan (>= 2.14.0),
     scales,
     stats,
-    tidyr (>= 0.6.1),
-    utils
+    tidyr (>= 0.6.1)
 Suggests:
     knitr,
     testthat,

--- a/R/R/prophet.R
+++ b/R/R/prophet.R
@@ -333,8 +333,7 @@ set_changepoints <- function(m) {
       # Place potential changepoints evenly through the first 80 pcnt of
       # the history.
       cp.indexes <- round(seq.int(1, floor(nrow(m$history) * .8),
-                          length.out = (m$n.changepoints + 1))) %>%
-                    utils::tail(-1)
+                          length.out = (m$n.changepoints + 1))[-1])
       m$changepoints <- m$history$ds[cp.indexes]
     } else {
       m$changepoints <- c()


### PR DESCRIPTION
Replace tail(-1) with [-1]

We get same results 

```
> tail(1:10, -1)
[1]  2  3  4  5  6  7  8  9 10
> (1:10)[-1]
[1]  2  3  4  5  6  7  8  9 10
```

and don't need to import utils package anymore. 