### PR TITLE
Add a function to pick practical change points (R)

### DIFF
--- a/R/R/prophet_pick_changepoints.R
+++ b/R/R/prophet_pick_changepoints.R
@@ -1,0 +1,40 @@
+#' Pick changepoints from prophet object
+#'
+#' @param model Prophet model object.
+#' @param digits Integer, indicating the number of decimal places to be used. Default 2.
+#'
+#' @return A data frame consists of changepoints, growth rates and delta (changes in the growth rates).
+#'
+#' @examples
+#' \dontrun{
+#' m <- prophet(df)
+#' prophet_pick_changepoints(m)
+#' }
+#'
+#' @export
+prophet_pick_changepoints <- function(model, digits = 2) {
+  df <- data.frame(cp = model$changepoints,
+                   cp.t = model$changepoints.t,
+                   delta = as.vector(model$params$delta))
+  while(nrow(df) > 1 && any(abs(df$delta) < 10^-digits)) {
+    ind <- which.min(abs(df$delta))
+    if (ind == 1) {
+      pos <- 2
+    } else if (ind == nrow(df) || 2 * df$cp.t[ind] < df$cp.t[ind-1] + df$cp.t[ind+1]) {
+      pos <- ind - 1
+    } else {
+      pos <- ind + 1
+    }
+    df$delta[pos] <- df$delta[pos] + df$delta[ind]
+    df <- df[-ind, , drop = FALSE]
+  }
+  if (nrow(df) == 1 && abs(df$delta) < 10^-digits) {
+    df <- data.frame()
+  }
+  cp <- c(model$start, df$cp)
+  delta <- c(0, df$delta)
+  growth_rate <- model$params$k + cumsum(delta)
+  result <- data.frame(changepoints = cp, growth_rate = growth_rate, delta = delta)
+  class(result) <- c("prophet_changepoint", class(result))
+  result
+}


### PR DESCRIPTION
Hello.
I suggest a function to pick practical change points from prophet model object.
Because prophet sparse estimates changes in the growth rates, we usually get change points contains nearly zero changes.

```r
> df <- read.csv("https://raw.githubusercontent.com/facebookincubator/prophet/master/examples/example_wp_peyton_manning.csv")
> df$y <- log(df$y)
> 
> library(prophet)
> m <- prophet(df, n.changepoints = 15)
> m$changepoints
 [1] "2008-05-18" "2008-11-13" "2009-04-17" "2009-09-18" "2010-03-05"
 [6] "2010-08-14" "2011-01-16" "2011-06-20" "2011-11-24" "2012-04-29"
[11] "2012-10-02" "2013-03-05" "2013-08-08" "2014-01-11" "2014-06-15"
> as.vector(m$params$delta)
 [1] -6.967408e-06  8.049281e-01 -4.754921e-08 -2.404752e-01 -2.007219e-01
 [6] -1.844382e-07  2.658313e-01  1.094812e-01  9.937361e-08 -8.180386e-01
[11]  1.398169e-06  5.498220e-01  2.451281e-07 -3.389944e-01 -1.024679e-07
```
It is more clear using `round` function: 
```r
> round(as.vector(m$params$delta), digits = 2)
 [1]  0.00  0.80  0.00 -0.24 -0.20
 [6]  0.00  0.27  0.11  0.00 -0.82
[11]  0.00  0.55  0.00 -0.34  0.00
```

Practically, we want to get only non-zero changes.
So I implemented `prophet_pick_changepoints` function:

```r
> prophet_pick_changepoints(m, digits = 2)
  changepoints growth_rate      delta
1   2007-12-10 -0.37995357  0.0000000
2   2008-11-13  0.42496753  0.8049211
3   2009-09-18  0.18449230 -0.2404752
4   2010-03-05 -0.01622959 -0.2007219
5   2011-01-16  0.24960149  0.2658311
6   2011-06-20  0.35908272  0.1094812
7   2012-04-29 -0.45895581 -0.8180385
8   2013-03-05  0.09086762  0.5498234
9   2014-01-11 -0.24812665 -0.3389943
```

How about it?